### PR TITLE
Bugfix for Passenger with smart spawning

### DIFF
--- a/lib/nanite/mapper.rb
+++ b/lib/nanite/mapper.rb
@@ -25,7 +25,6 @@ module Nanite
 
     DEFAULT_OPTIONS = COMMON_DEFAULT_OPTIONS.merge({
       :user => 'mapper',
-      :identity => Identity.generate,
       :agent_timeout => 15,
       :offline_redelivery_frequency => 10,
       :persistent => false,
@@ -114,6 +113,7 @@ module Nanite
       end
       options.delete(:identity) unless options[:identity]
       @options.update(custom_config.merge(options))
+      @options[:identity] ||= Identity.generate
       @identity = "mapper-#{@options[:identity]}"
       @options[:file_root] ||= File.join(@options[:root], 'files')
       @options[:log_path] = false

--- a/spec/mapper_spec.rb
+++ b/spec/mapper_spec.rb
@@ -21,6 +21,14 @@ describe Nanite::Mapper do
     it "should set the file root" do
       @mapper.options[:file_root].should == File.expand_path("#{File.dirname(__FILE__)}/../files")
     end
+    
+    it "should generate a new identity when not provided in the options or config file" do
+      @mapper1 = Nanite::Mapper.new({:root => ''})
+      @mapper2 = Nanite::Mapper.new({:root => ''})
+      @mapper1.identity.should =~ /mapper-.+/
+      @mapper2.identity.should =~ /mapper-.+/
+      @mapper1.identity.should_not == @mapper2.identity
+    end
   end
 
   describe "Starting" do


### PR DESCRIPTION
This fixes "eventmachine not initialized" errors on Passenger with smart spawning enabled.
A mapper's identity is supposed to be unique, since it acquires a unique lock on
the heartbeat-#{identity} queue. When the queue is already locked, things go wrong.
